### PR TITLE
feat: Implement news feed and UI enhancements

### DIFF
--- a/app/src/main/java/com/kobe/mimaa/ui/view/components/bottomSheets/NewsItemBtmSheet.kt
+++ b/app/src/main/java/com/kobe/mimaa/ui/view/components/bottomSheets/NewsItemBtmSheet.kt
@@ -1,0 +1,102 @@
+package com.kobe.mimaa.ui.view.components.bottomSheets
+
+
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.kobe.mimaa.R
+import com.kobe.mimaa.ui.view.components.rowIconText.RowContent
+import com.kobe.mimaa.ui.view.components.rowIconText.RowContentItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsItemBtmSheet(
+    link: String?,
+    isVisible: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState( skipPartiallyExpanded = true )
+    val listRowContent = listOf(
+        RowContentItem(
+            value = "Lire sur le site officiel", //dans le navigateur
+            icon = R.drawable.outward_arrow_icn,
+            onClick = { item->
+                link?.let { url->
+                    try {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                    }catch (e: Exception){
+                        Toast.makeText(context, "Erreur lors de l'ouverture du lien", Toast.LENGTH_SHORT).show()
+                    }
+                } ?: run {
+                    Toast.makeText(context, "Lien non disponible", Toast.LENGTH_SHORT).show()
+                }
+                onDismiss()
+            },
+        )
+    )
+
+    if (isVisible){
+        ModalBottomSheet(
+            onDismissRequest = { onDismiss() },
+            sheetState = sheetState,
+            tonalElevation = 4.dp,
+            dragHandle = {
+                Box(
+                    modifier = Modifier
+                        .padding(top = 16.dp, bottom = 8.dp)
+                        .width(40.dp)
+                        .height(4.dp)
+                        .background(Color.Gray, CircleShape)
+                )
+            },
+        ){
+            ContenairMorvertem(listRowContent = listRowContent)
+        }
+    }
+}
+
+@Composable
+fun ContenairMorvertem(
+    listRowContent: List<RowContentItem>,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(vertical = 8.dp)
+) {
+    Box( modifier = modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp) ){
+        Column(
+            modifier = Modifier.padding(contentPadding),
+            horizontalAlignment = Alignment.Start,
+            //verticalArrangement = Arrangement.Center,
+            //horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            listRowContent.forEachIndexed { index, item ->
+                RowContent(item = item)
+
+                // Ajout d'un Divider entre les éléments sauf pour le dernier
+                if (index < listRowContent.lastIndex) {
+                    Divider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        thickness = 1.dp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kobe/mimaa/ui/view/components/newsItem/FullScreenImageView.kt
+++ b/app/src/main/java/com/kobe/mimaa/ui/view/components/newsItem/FullScreenImageView.kt
@@ -1,0 +1,68 @@
+package com.kobe.mimaa.ui.view.components.newsItem
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FullScreenImageView(
+    imageUrl: String,
+    onDismiss: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Aperçu de l'image") },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Retour"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp), // Couleur de fond pour la top bar
+                    titleContentColor = MaterialTheme.colorScheme.onSurface,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onSurface
+                )
+            )
+        },
+        containerColor = Color.Black.copy(alpha = 0.8f) // Fond semi-transparent pour l'effet "lightbox"
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .clickable(onClick = onDismiss), // Permet de fermer en cliquant sur l'image/fond
+            contentAlignment = Alignment.Center
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .listener(onError = { _, _ -> onDismiss() }) // Si l'image ne peut pas se charger en plein écran, ferme le dialogue
+                    .build(),
+                contentDescription = "Image en plein écran",
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp) // Un peu de padding autour de l'image en plein écran
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/kobe/mimaa/ui/view/components/newsItem/NewsData.kt
+++ b/app/src/main/java/com/kobe/mimaa/ui/view/components/newsItem/NewsData.kt
@@ -1,0 +1,10 @@
+package com.kobe.mimaa.ui.view.components.newsItem
+
+data class NewsData(
+    val title: String,
+    val authorName: String,
+    val link: String?,
+    val partnerImageUrl: String?,
+    val newImageUrl: String?
+)
+

--- a/app/src/main/java/com/kobe/mimaa/ui/view/components/newsItem/NewsItem.kt
+++ b/app/src/main/java/com/kobe/mimaa/ui/view/components/newsItem/NewsItem.kt
@@ -1,0 +1,176 @@
+package com.kobe.mimaa.ui.view.components.newsItem
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil.compose.AsyncImage
+import com.kobe.mimaa.R
+import com.kobe.mimaa.ui.view.components.bottomSheets.NewsItemBtmSheet
+
+@Composable
+fun NewsItem(
+    title: String,
+    authorName: String,
+    link: String?,
+    partnerImageUrl: String?,
+    newImageUrl: String?,
+    contenair: Color = MaterialTheme.colorScheme.background,
+    content: Color = MaterialTheme.colorScheme.onBackground,
+    modifier: Modifier = Modifier.height(350.dp)
+) {
+    var showMoreVert by remember { mutableStateOf(false) }
+    var showFullScreenImage by remember { mutableStateOf<String?>(null) }
+
+    Card(
+        modifier = modifier,
+        elevation = CardDefaults.elevatedCardElevation(4.dp),
+        shape = RoundedCornerShape(8.dp),
+        //colors = CardDefaults.cardColors(containerColor = contenair) // Définir la couleur du conteneur ici
+    ){
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Box(modifier = Modifier
+                .weight(0.8f)
+                .clickable { newImageUrl?.let { link -> showFullScreenImage = link } }){
+                AsyncImage(
+                    model = newImageUrl,
+                    contentDescription = null,
+                    placeholder = painterResource(R.drawable.ic_launcher_background),
+                    error = painterResource(R.drawable.ic_launcher_background),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            Row (
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ){
+                Spacer(modifier = Modifier.width(0.dp))
+                AsyncImage(
+                    model = partnerImageUrl,
+                    contentDescription = null,
+                    placeholder = painterResource(R.drawable.nouser_profilepicture),
+                    error = painterResource(R.drawable.nouser_profilepicture),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .size(40.dp)
+                )
+
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        color = content
+                    ),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+
+                IconButton(
+                    onClick = {showMoreVert = !showMoreVert},
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.MoreVert,
+                        contentDescription = "moreVert"
+                    )
+                }
+            }
+
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 60.dp, vertical = 5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ){
+                Icon(
+                    painter = painterResource(R.drawable.verified_filled_icn),
+                    contentDescription = "Verified Entity",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = authorName,
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontStyle = FontStyle.Italic,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        showFullScreenImage?.let { imageUrl ->
+            Dialog(
+                onDismissRequest = { showFullScreenImage = null },
+                properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false) // Pour un vrai plein écran
+            ) {
+                FullScreenImageView(
+                    imageUrl = imageUrl,
+                    onDismiss = { showFullScreenImage = null }
+                )
+            }
+        }
+
+        if (showMoreVert){
+            NewsItemBtmSheet(
+                link = link,
+                isVisible = showMoreVert,
+                onDismiss = { showMoreVert = false}
+            )
+        }
+    }
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NewsImagePrevv(modifier: Modifier = Modifier) {
+    NewsItem(
+        title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+        authorName = "Ministere de la sante publique",
+        link = null,
+        partnerImageUrl = null,
+        newImageUrl = null,
+        modifier = Modifier.height(300.dp)
+    )
+}

--- a/app/src/main/java/com/kobe/mimaa/ui/view/components/rowIconText/RowContent.kt
+++ b/app/src/main/java/com/kobe/mimaa/ui/view/components/rowIconText/RowContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -37,7 +38,7 @@ fun RowContent(
     item: RowContentItem,
     trailingIcon: @Composable () -> Unit = {
         Icon(
-            imageVector = Icons.Default.KeyboardArrowRight,
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
             contentDescription = "Aller à",
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(24.dp)

--- a/app/src/main/java/com/kobe/mimaa/ui/view/components/rowIconText/RowContentItem.kt
+++ b/app/src/main/java/com/kobe/mimaa/ui/view/components/rowIconText/RowContentItem.kt
@@ -17,8 +17,8 @@ data class RowContentItem(
     val value: String,
     @DrawableRes val icon: Int,
     val keyboardType: KeyboardType = KeyboardType.Text,
-    val onClick: (RowContentItem) -> Unit, // Modifier le type de onClick
-    val onLongClick: ((RowContentItem) -> Unit)? = null // Ajouter une option pour un long clic
+    val onClick: (RowContentItem) -> Unit,
+    val onLongClick: ((RowContentItem) -> Unit)? = null
 )
 
 

--- a/app/src/main/java/com/kobe/mimaa/ui/view/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/kobe/mimaa/ui/view/homeScreen/HomeScreen.kt
@@ -4,10 +4,14 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,6 +23,8 @@ import com.kobe.mimaa.data.source.model.User
 import com.kobe.mimaa.ui.view.components.myBottomAppBar.MyBottomAppBar
 import com.kobe.mimaa.ui.view.components.myBottomAppBar.MyNavigationOnRail
 import com.kobe.mimaa.ui.view.components.myTopAppBar.MyTopBar
+import com.kobe.mimaa.ui.view.components.newsItem.NewsData
+import com.kobe.mimaa.ui.view.components.newsItem.NewsItem
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
@@ -27,10 +33,68 @@ fun HomeScreen(
     currentUser: User? = null
 ) {
     val user = currentUser ?: return
+    val news = listOf(
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+
+//        NewsItem(
+//            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+//            authorName = "Ministere de la sante publique",
+//            link = null,
+//            partnerImageUrl = null,
+//            newImageUrl = null,
+//            modifier = Modifier.height(300.dp)
+//        )
+    )
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()){
+        val maxWidth = maxWidth
         if(maxWidth > 600.dp){
             Row(modifier = Modifier.fillMaxSize()){
+                val columnCount = when {
+                    maxWidth > 1200.dp -> 4
+                    else -> 2
+                }
                 MyNavigationOnRail(navController = navController)
                 //other things
                 MyTopBar(
@@ -39,10 +103,17 @@ fun HomeScreen(
                     onNotificationClick = { /*--Rien pour le moment--*/ },
                     onSearchClick = { /*--Rien pour le moment--*/  }
                 )
-                Spacer(modifier = Modifier.weight(1f))
+
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(columnCount),
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ){
+                    //
+                }
             }
         }else{
-
             Scaffold(
                 topBar = {
                     MyTopBar(
@@ -56,15 +127,22 @@ fun HomeScreen(
                     MyBottomAppBar(navController = navController)
                 },
             ) { paddingValues ->
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues)
-                    ,
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(1),
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    contentPadding = PaddingValues(10.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
                 ){
-                    Text(text = "Bonjour ${user.email} comment vas tu ?",)
+                    items(news) { news->
+                        NewsItem(
+                            title = news.title,
+                            authorName = news.authorName,
+                            link = news.link,
+                            partnerImageUrl = news.partnerImageUrl,
+                            newImageUrl = news.newImageUrl,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/kobe/mimaa/ui/view/settingsScreen/SettingsScreen.kt
+++ b/app/src/main/java/com/kobe/mimaa/ui/view/settingsScreen/SettingsScreen.kt
@@ -84,7 +84,6 @@ fun SettingsScreen(
                     ) {
                         items(settingsItems.size) { index ->
                             val cardItems = settingsItems[index]
-
                             ContenairSettingsItems(
                                 listRowContent = cardItems,
                                 modifier = Modifier.fillMaxWidth()
@@ -108,32 +107,22 @@ fun SettingsScreen(
                     MyBottomAppBar(navController = navController)
                 }
             ) { paddingValues ->
-                BoxWithConstraints(modifier = Modifier.padding(paddingValues)) {
-                    val columnCount = when {
-                        maxWidth > 1200.dp -> 4// pc/web
-                        maxWidth > 600.dp -> 2//tablette
-                        else -> 1//smartphone
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(1),
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(settingsItems.size) { index ->  // Utilisation de .size et index
+                        val cardItems = settingsItems[index]
+                        ContenairSettingsItems(
+                            listRowContent = cardItems,
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
-
-                    LazyVerticalGrid(
-                        columns = GridCells.Fixed(columnCount),
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        items(settingsItems.size) { index ->  // Utilisation de .size et index
-                            val cardItems = settingsItems[index]
-                            ContenairSettingsItems(
-                                listRowContent = cardItems,
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-
-
                 }
+                Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }

--- a/app/src/main/res/drawable/outward_arrow_icn.xml
+++ b/app/src/main/res/drawable/outward_arrow_icn.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M6,6l0,2l8.59,0l-9.59,9.59l1.41,1.41l9.59,-9.59l0,8.59l2,0l0,-12z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/verified_filled_icn.xml
+++ b/app/src/main/res/drawable/verified_filled_icn.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M23,12l-2.44,-2.79l0.34,-3.69l-3.61,-0.82L15.4,1.5L12,2.96L8.6,1.5L6.71,4.69L3.1,5.5L3.44,9.2L1,12l2.44,2.79l-0.34,3.7l3.61,0.82L8.6,22.5l3.4,-1.47l3.4,1.46l1.89,-3.19l3.61,-0.82l-0.34,-3.69L23,12zM10.09,16.72l-3.8,-3.81l1.48,-1.48l2.32,2.33l5.85,-5.87l1.48,1.48L10.09,16.72z"/>
+    
+</vector>


### PR DESCRIPTION
This commit introduces a news feed feature on the `HomeScreen` and several UI improvements across the application.

- **News Feed (`HomeScreen.kt`):**
    - Displays a list of news items using `LazyVerticalGrid`.
    - Adapts column count based on screen width (4 for >1200dp, 2 for >600dp, 1 for smaller screens).
    - Integrates the new `NewsItem` composable to display individual news articles.
- **`NewsItem.kt` (New Component):**
    - Creates a card-based UI for displaying news articles with: - Image (clickable for full-screen view). - Title. - Author name with a verified icon. - "More options" (MoreVert) icon.
    - Placeholder and error images are used for `AsyncImage`.
    - Shows a `NewsItemBtmSheet` when the "MoreVert" icon is clicked.
    - Added `NewsData.kt` data class.
- **`FullScreenImageView.kt` (New Component):**
    - Displays an image in a full-screen dialog with a top app bar and a back button.
    - Allows dismissing by clicking on the image or the back button.
- **`NewsItemBtmSheet.kt` (New Bottom Sheet):**
    - Provides an option to "Lire sur le site officiel" (Read on official site), which opens the article link in a browser.
    - Handles cases where the link is unavailable or an error occurs during opening.
- **Settings Screen (`SettingsScreen.kt`):**
    - Simplified `LazyVerticalGrid` to use a fixed column count of 1, removing adaptive column logic.
- **Row Content (`RowContent.kt`):**
    - Updated `KeyboardArrowRight` icon to its auto-mirrored version (`Icons.AutoMirrored.Filled.KeyboardArrowRight`).
- **New Drawables:**
    - Added `verified_filled_icn.xml` for the verified author icon.
    - Added `outward_arrow_icn.xml` for the "open in new" icon in the bottom sheet.
- **Minor type hint update in `RowContentItem.kt`.**